### PR TITLE
Humans.txt detector regex fixed

### DIFF
--- a/js/detector.js
+++ b/js/detector.js
@@ -188,7 +188,7 @@
         'Moodle': /<link[^>]*\/theme\/standard\/styles.php".*>|<link[^>]*\/theme\/styles.php\?theme=.*".*>/,
         '1c-bitrix': /<link[^>]*\/bitrix\/.*?>/i,
         'OpenCMS': /<link[^>]*\.opencms\..*?>/i,
-        'HumansTxt': /<link[^>]*rel=['"]?author['"]?/i,
+        'HumansTxt': /<link[^>]*href=['"]?\S*?humans\.txt.*?['"].*?\>/i,
         'GoogleFontApi': /ref=["']?http:\/\/fonts.googleapis.com\//i,
         'Prostores': /-legacycss\/Asset">/,
         'osCommerce': /(product_info\.php\?products_id|_eof \/\/-->)/,


### PR DESCRIPTION
Humans.txt text test was returning false positives, matching any link
tag with a rel=author attribute.  Patch looks for the actual humans.txt file.

Solves #67
