### PR TITLE
Update URL for Google Loader

### DIFF
--- a/js/apps.js
+++ b/js/apps.js
@@ -703,7 +703,7 @@ var appinfo = {
     },
     'Google Loader': {
         icon: 'google.ico',
-        url: 'http://code.google.com/apis/loader',
+        url: 'https://developers.google.com/loader/',
         priority: 2.9
     },
 


### PR DESCRIPTION
I’m not familiar with Google Loader, so I have not yet verified that this is the correct URL. The original URL is dead though.